### PR TITLE
Add option to download cookies for all domains

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,7 @@
 	<body>
 		<pre># Cookies for this tab
 # <a href="#" id="download-link" download="cookies.txt">Click here</a> to download them
+# <a href="#" id="download-all"  download="cookies.txt">Click here</a> to download cookies for all domains
 
 <div id="cookies"></div>
 </pre>

--- a/popup.js
+++ b/popup.js
@@ -49,3 +49,9 @@ formatActiveTabCookies()
 	document.getElementById('download-link').href = 'data:text/plain,' + encodeURIComponent(cookiesText)
 	document.getElementById('cookies').innerText = cookiesText
 })
+
+browser.cookies.getAll({})
+.then(formatCookieFile)
+.then((cookiesText) => {
+	document.getElementById('download-all').href = 'data:text/plain,' + encodeURIComponent(cookiesText)
+})


### PR DESCRIPTION
This adds a second link to the popup allowing the user to download all cookies currently stored in the browser. This means the resulting "cookie.txt" file can be reused for multiple websites instead of having to create separate files for each.

I have tested the changes on Firefox 70.0.