### PR TITLE
Add initial support for First Party Isolation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
 	"permissions": [
 		"<all_urls>",
 		"cookies",
-		"tabs"
+		"tabs",
+		"privacy"
 	]
 }

--- a/popup.html
+++ b/popup.html
@@ -8,7 +8,7 @@
 	<body>
 		<pre># Cookies for this tab
 # <a href="#" id="download-link" download="cookies.txt">Click here</a> to download them
-# <a href="#" id="download-all"  download="cookies.txt">Click here</a> to download cookies for all domains
+<div id="link-placeholder"></div>
 
 <div id="cookies"></div>
 </pre>

--- a/popup.js
+++ b/popup.js
@@ -39,8 +39,35 @@ function formatActiveTabCookies() {
 	return getActiveTab()
 	.then((tabs) => {
 		const tab = tabs.pop()
-		return browser.cookies.getAll({url: tab.url})
-		.then(formatCookieFile)
+		return Promise.all([Promise.resolve(tab.url), getFirstPartyDomain(tab.url)])
+		.then((results) => {
+			return browser.cookies.getAll({
+				url: results[0],
+				firstPartyDomain: results[1]
+			})
+			.then(formatCookieFile)
+		})
+	})
+}
+
+function isFirstPartyIsolated() {
+	return browser.privacy.websites.firstPartyIsolate.get({}).then((result) => result.value)
+}
+
+/* This function is inteded to return the actual first Party Domain if FPI is enabled and "" otherwise. 
+ * Since there are some difficulties exttacting the FP-Domain form the url this method returns null if
+ * FPI is enabled. When an actual fix is available either edit or replace this method.
+ * 
+ * See also: https://github.com/emersion/ganbo/issues/1
+*/
+function getFirstPartyDomain(url) {
+	return isFirstPartyIsolated()
+	.then((isolated) => {
+		if (isolated) {
+			return null
+		} else {
+			return ""
+		}
 	})
 }
 
@@ -50,8 +77,18 @@ formatActiveTabCookies()
 	document.getElementById('cookies').innerText = cookiesText
 })
 
-browser.cookies.getAll({})
-.then(formatCookieFile)
-.then((cookiesText) => {
-	document.getElementById('download-all').href = 'data:text/plain,' + encodeURIComponent(cookiesText)
+/* Only enable cookies for all domains when FPI is disabled */
+isFirstPartyIsolated()
+.then((isolated) => {
+	if (isolated) {
+		document.getElementById('link-placeholder').innerText = '# Downloading cookies for all domains is not available when First Party Isolation is enabled.'
+	} else {
+		document.getElementById('link-placeholder').innerHTML = '# <a href="#" id="download-all"  download="cookies.txt">Click here</a> to download cookies for all domains'
+
+		browser.cookies.getAll({})
+		.then(formatCookieFile)
+		.then((cookiesText) => {
+			document.getElementById('download-all').href = 'data:text/plain,' + encodeURIComponent(cookiesText)
+		})
+	}
 })


### PR DESCRIPTION
This PR addresses issue #1.

As I have stated in this issue this is not a perfect fix but it makes the extension usable for all websites which only use First Party Cookies for authentication. Third Party login systems will not work with FPI enabled but this is an intended browser limitation.

Some notes on this PR:
- I have added a new permission to allow the extension access to the "privacy" API. This is necessary to query the status of FPI.
- The extension excludes cookies with a FP-Domain if FPI is disabled but will not exclude cookies without a FP-Domain if FPI is enabled.
- I have left in some relatively useless functions (such as getFirstPartyDomain). These are meant to act as a useful component once the FP-Domain can be extracted from a URL.

What still doesn't work:
- 
- Third Party Cookies do not get extracted (this is unrelated to FPI and deserves its own, separate issue).
- When the extension attempts to extract cookies with the same Domain+Name combination but different FP-Domains it will generate a corrupt cookie.txt file. This shouldn't happen right now as the extension doesn't extract Third Party cookies but it might do so in the future (see above).
- Extracting cookies for all domains is disabled when FPI is enabled and will probably not ever work because the Netscape Cookie Format has no concept of FPI.

I would suggest closing #1 as this extension now supports FPI in its current state and opening a new issue to track the more complicated process of extracting the FP-Domain.
Additionally a separate issue to track the proper handling of third party cookies would be useful as this is largely independent of FPI.

I have tested this on Firefox 70.0.
without FPI: my standard browser profile
with FPI: a new temporary profile with privacy.firstparty.isolate set to true.